### PR TITLE
Added error check for empty results

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,8 +34,12 @@ module.exports = (function () {
 
             // Parse body
 
-            var res1 = JSON.parse(body),
-                steamID = res1.items[0].id,
+            var res1 = JSON.parse(body)
+            if(res1.total == 0) {
+                return callback(new Error('No results found'));
+            }
+
+            var steamID = res1.items[0].id,
                 reqUrl2 = `http://store.steampowered.com/api/appdetails?appids=${steamID}`
 
             request.get({


### PR DESCRIPTION
An undefined error occurred when the results were empty. This should now instead return an error that dependent programs can check for.